### PR TITLE
Implement custom table name in models

### DIFF
--- a/src/Models/Bookmark.php
+++ b/src/Models/Bookmark.php
@@ -14,6 +14,11 @@ class Bookmark extends Model
         'url',
     ];
 
+    public function getTable(): string
+    {
+        return config('page-bookmarks.tables.bookmarks', 'bookmarks');
+    }
+
     public function user(): BelongsTo
     {
         return $this->belongsTo(config('page-bookmarks.models.user', config('auth.providers.users.model')));

--- a/src/Models/BookmarkFolder.php
+++ b/src/Models/BookmarkFolder.php
@@ -13,6 +13,11 @@ class BookmarkFolder extends Model
         'name',
     ];
 
+    public function getTable(): string
+    {
+        return config('page-bookmarks.tables.bookmark_folders', 'bookmark_folders');
+    }
+
     public function user(): BelongsTo
     {
         return $this->belongsTo(config('page-bookmarks.models.user', config('auth.providers.users.model')));


### PR DESCRIPTION
This pull request introduces changes to improve configurability for database table names in the models `Bookmark` and `BookmarkFolder`. The most important changes involve adding a `getTable` method to each model, allowing the table names to be dynamically set via configuration.

### Configurability improvements:

* [`src/Models/Bookmark.php`](diffhunk://#diff-dd3047aec21f675c63706633a228f1c607d4062f88b0a0680de45eca7eadd77fR17-R21): Added a `getTable` method to dynamically retrieve the table name for the `Bookmark` model from the configuration file, with a default fallback to `'bookmarks'`.
* [`src/Models/BookmarkFolder.php`](diffhunk://#diff-3053373219715501ff4b00bfd208352cb90cbbc283d8c4fba44a4e3c2aec7060R16-R20): Added a `getTable` method to dynamically retrieve the table name for the `BookmarkFolder` model from the configuration file, with a default fallback to `'bookmark_folders'`.