### PR TITLE
Fix namespace casing in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,13 +9,13 @@
     "license": "MIT",
     "autoload": {
         "psr-4": {
-            "Jaysontemporas\\PageBookmarks\\": "src/"
+            "JaysonTemporas\\PageBookmarks\\": "src/"
         }
     },
     "extra": {
         "laravel": {
             "providers": [
-                "Jaysontemporas\\PageBookmarks\\PageBookmarksServiceProvider"
+                "JaysonTemporas\\PageBookmarks\\PageBookmarksServiceProvider"
             ]
         }
     },


### PR DESCRIPTION
This is not just cosmetics, but at least on my system (linux) autoloading is broken, since of case sensitive paths